### PR TITLE
Output RIBsTree in Markdown list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RIBsTreeMaker visualize [RIBs](https://github.com/uber/RIBs) business logic tree
 
 ## Usage
 ```
-swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plantUML or whimsical (default: plantUML)]] [--summary]
+swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plantUML or markdown (default: plantUML)]] [--summary]
 ```
 
 ### Options
@@ -18,7 +18,7 @@ swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plant
 * **under**: The tree will be displayed only under the RIB.
 * **format**: Specify the output format. The format that can be specified is as follows:
   * **plantUML(Default)**: The output is in PlantUML format.
-  * **whimsical**: Outputs code that can be used in [Whimsical](https://whimsical.com).
+  * **markdown**: The output is in Markdown list format..
 * **summary**: The RIB's summary is displayed in the node. The summary is retrieved `// SUMMARY: RIB summary` from the Builder file.
 
 ## Visualize for mindmap

--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ RIBsTreeMaker visualize [RIBs](https://github.com/uber/RIBs) business logic tree
 
 ## Usage
 ```
-swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--summary]
+swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plantUML or whimsical (default: plantUML)]] [--summary]
 ```
 
 ### Options
 
 * **under**: The tree will be displayed only under the RIB.
+* **format**: Specify the output format. The format that can be specified is as follows:
+  * **plantUML(Default)**: The output is in PlantUML format.
+  * **whimsical**: Outputs code that can be used in [Whimsical](https://whimsical.com).
 * **summary**: The RIB's summary is displayed in the node. The summary is retrieved `// SUMMARY: RIB summary` from the Builder file.
-
 
 ## Visualize for mindmap
 The output style is org-mode mindmap.

--- a/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
+++ b/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct HelpCommand: Command {
     func run() -> Result {
-        let helpMessage = "USAGE: RIBsTreeMaker [analyze target path] [--under [RIB name]] [--summary]"
+        let helpMessage = "USAGE: RIBsTreeMaker [analyze target path] [--under [RIB name]] [--format [plantUML or whimsical (default: plantUML)]] [--summary]"
         return .success(message: helpMessage)
     }
 }

--- a/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
+++ b/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct HelpCommand: Command {
     func run() -> Result {
-        let helpMessage = "USAGE: RIBsTreeMaker [analyze target path] [--under [RIB name]] [--format [plantUML or whimsical (default: plantUML)]] [--summary]"
+        let helpMessage = "USAGE: RIBsTreeMaker [analyze target path] [--under [RIB name]] [--format [plantUML or markdown (default: plantUML)]] [--summary]"
         return .success(message: helpMessage)
     }
 }

--- a/Sources/RIBsTreeMaker/Commands/MainCommand.swift
+++ b/Sources/RIBsTreeMaker/Commands/MainCommand.swift
@@ -38,8 +38,8 @@ extension MainCommand: Command {
             case .plantUML:
                 let treeMaker = PlantUMLFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, paths: paths)
                 try treeMaker.make()
-            case .whimsical:
-                let treeMaker = WhismicalFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, paths: paths)
+            case .markdown:
+                let treeMaker = MarkdownFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, paths: paths)
                 try treeMaker.make()
             }
             return .success(message: "\nSuccessfully completed.".green.applyingStyle(.bold))

--- a/Sources/RIBsTreeMaker/FormatType.swift
+++ b/Sources/RIBsTreeMaker/FormatType.swift
@@ -1,0 +1,22 @@
+//
+//  FormatType.swift
+//  RIBsTreeMaker
+//
+//  Created by Natsuki Idota on 2023/09/12.
+//
+
+enum FormatType {
+    case plantUML
+    case whimsical
+
+    init(value: String?) {
+        switch value {
+        case "plantUML":
+            self = .plantUML
+        case "whimsical":
+            self = .whimsical
+        default:
+            self = .plantUML
+        }
+    }
+}

--- a/Sources/RIBsTreeMaker/FormatType.swift
+++ b/Sources/RIBsTreeMaker/FormatType.swift
@@ -7,14 +7,14 @@
 
 enum FormatType {
     case plantUML
-    case whimsical
+    case markdown
 
     init(value: String?) {
         switch value {
         case "plantUML":
             self = .plantUML
-        case "whimsical":
-            self = .whimsical
+        case "markdown":
+            self = .markdown
         default:
             self = .plantUML
         }

--- a/Sources/RIBsTreeMaker/TreeMaker/MarkdownFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/MarkdownFormatTreeMaker.swift
@@ -27,17 +27,8 @@ struct MarkdownFormatTreeMaker: TreeMaker {
 private extension MarkdownFormatTreeMaker {
     func showRIBsTree(edges: [Edge], targetName: String, count: Int) throws {
         var summary = ""
-        var prefix = ""
-
-        if count > 2 {
-            for _ in 2..<count {
-                prefix += "  "
-            }
-        }
-
-        if count >= 2 {
-            prefix += "- "
-        }
+        let maximumCount = max(0, count - 1)
+        let prefix = String(repeating: "  ", count: maximumCount) + "- "
 
         let viewControllablers = extractViewController(from: edges)
         let hasViewController = viewControllablers.contains(targetName)

--- a/Sources/RIBsTreeMaker/TreeMaker/MarkdownFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/MarkdownFormatTreeMaker.swift
@@ -1,11 +1,11 @@
 //
-//  WhismicalFormatTreeMaker.swift
+//  MarkdownFormatTreeMaker.swift
 //  RIBsTreeMaker
 //
 //  Created by Natsuki Idota on 2023/09/19.
 //
 
-struct WhismicalFormatTreeMaker: TreeMaker {
+struct MarkdownFormatTreeMaker: TreeMaker {
     let edges: [Edge]
     let rootRIBName: String
     let shouldShowSummary: Bool
@@ -24,7 +24,7 @@ struct WhismicalFormatTreeMaker: TreeMaker {
 }
 
 // MARK: - Private Methods
-private extension WhismicalFormatTreeMaker {
+private extension MarkdownFormatTreeMaker {
     func showRIBsTree(edges: [Edge], targetName: String, count: Int) throws {
         var summary = ""
         var prefix = ""

--- a/Sources/RIBsTreeMaker/TreeMaker/PlantUMLFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/PlantUMLFormatTreeMaker.swift
@@ -1,0 +1,88 @@
+//
+//  PlantUMLFormatTreeMaker.swift
+//  RIBsTreeMaker
+//
+//  Created by Natsuki Idota on 2023/09/19.
+//
+
+struct PlantUMLFormatTreeMaker: TreeMaker {
+    let edges: [Edge]
+    let rootRIBName: String
+    let shouldShowSummary: Bool
+    let paths: [String]
+
+    init(edges: [Edge], rootRIBName: String, shouldShowSummary: Bool, paths: [String]) {
+        self.edges = edges
+        self.rootRIBName = rootRIBName
+        self.shouldShowSummary = shouldShowSummary
+        self.paths = paths
+    }
+
+    func make() throws {
+        showHeader()
+        showMindmapStyle()
+        try showRIBsTree(edges: edges, targetName: rootRIBName, count: 1)
+        showFooter()
+    }
+}
+
+// MARK: - Private Methods
+private extension PlantUMLFormatTreeMaker {
+    func showRIBsTree(edges: [Edge], targetName: String, count: Int) throws {
+        var summary = ""
+        var indent = ""
+
+        for _ in 0..<count {
+            indent += "*"
+        }
+
+        let viewControllablers = extractViewController(from: edges)
+        let hasViewController = viewControllablers.contains(targetName)
+        let suffix = hasViewController ? "" : "<<noView>>"
+        if shouldShowSummary, let retrievedSummaryComment = try retrieveSummaryComment(targetName: targetName) {
+            summary = " / \(retrievedSummaryComment)"
+        }
+        print(indent + " " + targetName + summary + suffix)
+
+        for edge in edges {
+            if let interactable = extractInteractable(from: edge.leftName) {
+                if interactable == targetName {
+                    if let listener = extractListener(from: edge.rightName) {
+                        try showRIBsTree(edges: edges, targetName: listener, count: count + 1)
+                    }
+                }
+            }
+        }
+    }
+
+    func showMindmapStyle() {
+        let style = """
+        <style>
+        mindmapDiagram {
+          . * {
+            BackGroundColor #FFF
+            LineColor #192f60
+            Shadowing 0.0
+            RoundCorner 20
+            LineThickness 2.0
+          }
+          .noView * {
+            BackGroundColor #FFF
+            LineColor #d20b52
+            TextColor #d20b52
+          }
+        }
+        </style>
+        """
+
+        print(style)
+    }
+
+    func showHeader() {
+        print("@startmindmap")
+    }
+
+    func showFooter() {
+        print("@endmindmap")
+    }
+}

--- a/Sources/RIBsTreeMaker/TreeMaker/TreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/TreeMaker.swift
@@ -1,0 +1,74 @@
+//
+//  TreeMaker.swift
+//  RIBsTreeMaker
+//
+//  Created by Natsuki Idota on 2023/09/19.
+//
+
+import Foundation
+import Rainbow
+
+protocol TreeMaker {
+    var paths: [String] { get }
+
+    func make() throws
+}
+
+extension TreeMaker {
+    func retrieveSummaryComment(targetName: String) throws -> String? {
+        let regexPattern = "// SUMMARY: .+"
+        let summaryComment = "// SUMMARY: "
+        let lineSeparator = "\n"
+        let suffixOfBuilderFile = "Builder.swift"
+        let targetFile = "/\(targetName)\(suffixOfBuilderFile)"
+        guard let builder = paths.filter({ $0.contains(targetFile) }).first else {
+            return nil
+        }
+
+        do {
+            let contents = try String(contentsOfFile: builder, encoding: .utf8)
+            let regex = try NSRegularExpression(pattern: regexPattern)
+            let results = regex.matches(in: contents, range: NSRange(0..<contents.count))
+            guard let result = results.first else {
+                return nil
+            }
+            if result.numberOfRanges == 0 {
+                return nil
+            }
+            let start = contents.index(contents.startIndex, offsetBy: result.range(at: 0).location)
+            let end = contents.index(start, offsetBy: result.range(at: 0).length)
+            return String(contents[start..<end]).replacingOccurrences(of: summaryComment, with: "").replacingOccurrences(of: lineSeparator, with: "")
+        }
+        catch {
+            print("Cannot retrieve summary comment. Check the target path or the Builder file.".red)
+            throw Error.failedToRetrieveSummary
+        }
+    }
+
+    func extractInteractable(from name: String) -> String? {
+        if name.contains("Interactable") {
+            return name.replacingOccurrences(of: "Interactable", with: "")
+        } else {
+            return nil
+        }
+    }
+
+    func extractListener(from name: String) -> String? {
+        if name.contains("Listener") {
+            return name.replacingOccurrences(of: "Listener", with: "")
+        } else {
+            return nil
+        }
+    }
+
+    func extractViewController(from edges: [Edge]) -> Set<String> {
+        let results = edges.compactMap { edge -> String? in
+            if edge.leftName.contains("ViewController") {
+                return edge.leftName.replacingOccurrences(of: "ViewController", with: "")
+            } else {
+                return nil
+            }
+        }
+        return Set<String>(results)
+    }
+}

--- a/Sources/RIBsTreeMaker/TreeMaker/WhismicalFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/WhismicalFormatTreeMaker.swift
@@ -1,0 +1,60 @@
+//
+//  WhismicalFormatTreeMaker.swift
+//  RIBsTreeMaker
+//
+//  Created by Natsuki Idota on 2023/09/19.
+//
+
+struct WhismicalFormatTreeMaker: TreeMaker {
+    let edges: [Edge]
+    let rootRIBName: String
+    let shouldShowSummary: Bool
+    let paths: [String]
+
+    init(edges: [Edge], rootRIBName: String, shouldShowSummary: Bool, paths: [String]) {
+        self.edges = edges
+        self.rootRIBName = rootRIBName
+        self.shouldShowSummary = shouldShowSummary
+        self.paths = paths
+    }
+
+    func make() throws {
+        try showRIBsTree(edges: edges, targetName: rootRIBName, count: 1)
+    }
+}
+
+// MARK: - Private Methods
+private extension WhismicalFormatTreeMaker {
+    func showRIBsTree(edges: [Edge], targetName: String, count: Int) throws {
+        var summary = ""
+        var prefix = ""
+
+        if count > 2 {
+            for _ in 2..<count {
+                prefix += "  "
+            }
+        }
+
+        if count >= 2 {
+            prefix += "- "
+        }
+
+        let viewControllablers = extractViewController(from: edges)
+        let hasViewController = viewControllablers.contains(targetName)
+        let noView = hasViewController ? "" : "(NoView)"
+        if shouldShowSummary, let retrievedSummaryComment = try retrieveSummaryComment(targetName: targetName) {
+            summary = " / \(retrievedSummaryComment)"
+        }
+        print(prefix + targetName + noView + summary)
+
+        for edge in edges {
+            if let interactable = extractInteractable(from: edge.leftName) {
+                if interactable == targetName {
+                    if let listener = extractListener(from: edge.rightName) {
+                        try showRIBsTree(edges: edges, targetName: listener, count: count + 1)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/RIBsTreeMaker/main.swift
+++ b/Sources/RIBsTreeMaker/main.swift
@@ -41,7 +41,9 @@ func makeCommand(commandLineArguments: [String]) -> Command {
         let paths = allSwiftSourcePaths(directoryPath: firstArgument)
         let rootRIBName = arguments["under"] ?? "Root"
         let shouldShowSummary = arguments["summary"] != nil
-        return MainCommand(paths: paths, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary)
+        let formatType = FormatType(value: arguments["format"])
+
+        return MainCommand(paths: paths, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, formatType: formatType)
     }
 }
 


### PR DESCRIPTION
## Description

* Add `-- format` option to the command, and convert from `--format` value to FormatType and pass to MainCommand.
* Add `TreeMaker` protocol. Add `PlantUMLFormatTreeMaker` and `MarkdownFormatTreeMaker` to conform to `TreeMaker`.
* The common processing for `PlantUMLFormatTreeMaker` and `MarkdownFormatTreeMaker` , previously described in `MainCommand` , has been moved to `TreeMaker` , and the methods described in `MainCommand` that are used only with `PlantUMLFormatTreeMaker` have been moved to `PlantUMLFormatTreeMaker` .

## Usage

command:

```sh
swift run RIBsTreeMaker [path/to/iOSproject] --under Root --format markdown --summary
```

output:

```
- Root / root summary
  - LoggedOut(NoView) / loggedOut summary
    - TermsOfUse
      - FailedLoading
    - Welcome
      -  SignInFailedDialog
      - ForgotPassword
        - SMSAuthentication
        - ResetPassword
  - LoggedIn(NoView)
```

paste in Whimsical:

<img width="1133" alt="スクリーンショット 2023-09-26 22 41 03" src="https://github.com/imairi/RIBsTreeMaker/assets/10494192/ad7ca303-da23-445c-ba66-2242b6cb0b78">

