### PR TITLE
Fix PlantUML style

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ The output style is org-mode mindmap.
 
 ```uml
 @startmindmap
-* Root
-** LoggedOut<<noView>>
-*** TermsOfUse
-**** FailedLoading
-*** Welcome
-**** SignInFailedDialog
-**** ForgotPassword
-***** SMSAuthentication
-****** ResetPassword
-** LoggedIn<<noView>>
+* Root<<hasView>>
+** LoggedOut
+*** TermsOfUse<<hasView>>
+**** FailedLoading<<hasView>>
+*** Welcome<<hasView>>
+**** SignInFailedDialog<<hasView>>
+**** ForgotPassword<<hasView>>
+***** SMSAuthentication<<hasView>>
+****** ResetPassword<<hasView>>
+** LoggedIn@endmindmap
 @endmindmap
 ```
 
@@ -44,16 +44,23 @@ Additionally, the mindmap style is set to detect easily the RIB has own view or 
 ```
 <style>
 mindmapDiagram {
-  . * {
-    BackGroundColor #FFF
-    LineColor #192f60
-    Shadowing 0.0
-    RoundCorner 20
-    LineThickness 2.0
+  BackgroundColor translate
+  LineColor #d20b52
+  FontColor #d20b52
+  RoundCorner 30
+  LineThickness 2.0
+
+  node {
+    BackgroundColor #fff
   }
-  .noView * {
-    BackGroundColor #FFF
-    LineColor #d20b52
+
+  arrow {
+    LineColor #192f60
+  }
+
+  .hasView {
+    LineColor #192f60
+    FontColor #192f60
   }
 }
 </style>

--- a/Sources/RIBsTreeMaker/TreeMaker/PlantUMLFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/PlantUMLFormatTreeMaker.swift
@@ -38,7 +38,7 @@ private extension PlantUMLFormatTreeMaker {
 
         let viewControllablers = extractViewController(from: edges)
         let hasViewController = viewControllablers.contains(targetName)
-        let suffix = hasViewController ? "" : "<<noView>>"
+        let suffix = hasViewController ? "<<hasView>>" : ""
         if shouldShowSummary, let retrievedSummaryComment = try retrieveSummaryComment(targetName: targetName) {
             summary = " / \(retrievedSummaryComment)"
         }
@@ -59,17 +59,23 @@ private extension PlantUMLFormatTreeMaker {
         let style = """
         <style>
         mindmapDiagram {
-          . * {
-            BackGroundColor #FFF
-            LineColor #192f60
-            Shadowing 0.0
-            RoundCorner 20
-            LineThickness 2.0
+          BackgroundColor translate
+          LineColor #d20b52
+          FontColor #d20b52
+          LineThickness 2.0
+
+          node {
+            BackgroundColor #fff
+            RoundCorner 30
           }
-          .noView * {
-            BackGroundColor #FFF
-            LineColor #d20b52
-            TextColor #d20b52
+
+          arrow {
+            LineColor #192f60
+          }
+
+          .hasView {
+            LineColor #192f60
+            FontColor #192f60
           }
         }
         </style>


### PR DESCRIPTION
## Description
The current PlantUML style applies the `.noView` style to Nodes under `.noView`. Therefore, fix it.

* Fix PlantUML style
  * Color codes were corrected to lowercase
* Nodes with no corresponding view had `<noview>` displayed. With this fix, nodes with a corresponding view display `<hasView>`.

## Output

### Before

```
@startmindmap
<style>
mindmapDiagram {
  . * {
    BackGroundColor #FFF
    LineColor #192f60
    Shadowing 0.0
    RoundCorner 20
    LineThickness 2.0
  }
  .noView * {
    BackGroundColor #FFF
    LineColor #d20b52
  }
}
</style>
* Root
** LoggedOut<<noView>>
*** TermsOfUse
**** FailedLoading
*** Welcome
**** SignInFailedDialog
**** ForgotPassword
***** SMSAuthentication
****** ResetPassword
** LoggedIn<<noView>>
@endmindmap
```

![bP51IyGm48Nl-HK3tdfOQq51A6NLfR9GMR6hdcCpcuPjPoH9AIBxturfaBrwAlFDU_DUoTfvQVreI8toKvJEVmrOYJHlZDHMZl0j05QGnI_0lUoEZvOdKWyyi8MBkgxZeZ642LtT5eURFDAsbufdGnhorK9U5gybj53aVzPzRxeZeNDGHE7fDvNupU3yhsnLv1_NHJnm4kLb-YMHXLps8ikWOQrHxIPVbilvgWeuWptQqUqE](https://github.com/imairi/RIBsTreeMaker/assets/10494192/82d9d438-604b-4be9-966b-7f241e211ec0)


### After

```
@startmindmap
<style>
mindmapDiagram {
  BackgroundColor translate
  LineColor #d20b52
  FontColor #d20b52
  LineThickness 2.0

  node {
    BackgroundColor #fff
    RoundCorner 30
  }

  arrow {
    LineColor #192f60
  }

  .hasView {
    LineColor #192f60
    FontColor #192f60
  }
}
</style>
* Root<<hasView>>
** LoggedOut
*** TermsOfUse<<hasView>>
**** FailedLoading<<hasView>>
*** Welcome<<hasView>>
**** SignInFailedDialog<<hasView>>
**** ForgotPassword<<hasView>>
***** SMSAuthentication<<hasView>>
****** ResetPassword<<hasView>>
** LoggedIn
@endmindmap
```

![PP91IyD048Nl-oiMUikXneY244hLKYXKAhRgUSnEjakJ6TcTKaJwtrtDIcrotFU-zsOcP1e4lBIEJ0iVgWposU14fVVCWVNGwY-bzJrKE-jvJ-Q16_PQF51eG31wIqVOgIDJvE_NHTJcJDBNdhku9_JwAa_1pTPLEy8GT37ELHI93VwE70uTrNKTZUCF1jxp8N6d1VJeyhQeR_8_Qho5yEfm29wuVxkUfO-gl4ZVGsLnTvQo](https://github.com/imairi/RIBsTreeMaker/assets/10494192/3b06a0de-4a00-42eb-99b1-b43c47ed8478)
