### PR TITLE
Add exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RIBsTreeMaker visualize [RIBs](https://github.com/uber/RIBs) business logic tree
 
 ## Usage
 ```
-swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plantUML or markdown (default: plantUML)]] [--summary]
+swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plantUML or markdown (default: plantUML)]] [--summary] [--excluded [RIB name]]
 ```
 
 ### Options
@@ -20,6 +20,7 @@ swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plant
   * **plantUML(Default)**: The output is in PlantUML format.
   * **markdown**: The output is in Markdown list format..
 * **summary**: The RIB's summary is displayed in the node. The summary is retrieved `// SUMMARY: RIB summary` from the Builder file.
+* **exclude**: The specified RIB and the RIB below it are not displayed. When specifying multiple RIB names, separate each RIB name with `,`.
 
 ## Visualize for mindmap
 The output style is org-mode mindmap.

--- a/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
+++ b/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
@@ -9,7 +9,17 @@ import Foundation
 
 struct HelpCommand: Command {
     func run() -> Result {
-        let helpMessage = "USAGE: RIBsTreeMaker [analyze target path] [--under [RIB name]] [--format [plantUML or markdown (default: plantUML)]] [--summary]"
+        let helpMessage = """
+        USAGE: RIBsTreeMaker <analyze target path> [options]
+
+        Options:
+          --under <value>      The tree will be displayed only under the RIB.
+          --format <value>     Specify the output format. The format that can be specified is as follows:
+                               plantUML(Default): The output is in PlantUML format.
+                               markdown: The output is in Markdown list format.
+          --summary            The RIB's summary is displayed in the node. The summary is retrieved `// SUMMARY: RIB summary` from the Builder file.
+          --exclude <value>    The specified RIB and the RIB below it are not displayed. When specifying multiple RIB names, separate each RIB name with `,`.
+        """
         return .success(message: helpMessage)
     }
 }

--- a/Sources/RIBsTreeMaker/Commands/MainCommand.swift
+++ b/Sources/RIBsTreeMaker/Commands/MainCommand.swift
@@ -13,9 +13,10 @@ struct MainCommand {
     private let rootRIBName: String
     private let shouldShowSummary: Bool
     private let formatType: FormatType
+    private let excludedRIBs: [String]
     private let paths: [String]
 
-    init(paths: [String], rootRIBName: String, shouldShowSummary: Bool, formatType: FormatType) {
+    init(paths: [String], rootRIBName: String, shouldShowSummary: Bool, formatType: FormatType, excludedRIBs: [String]) {
         print("")
         print("Analyze \(paths.count) swift files.".applyingStyle(.bold))
         print("")
@@ -24,6 +25,7 @@ struct MainCommand {
         self.rootRIBName = rootRIBName
         self.shouldShowSummary = shouldShowSummary
         self.formatType = formatType
+        self.excludedRIBs = excludedRIBs
         self.paths = paths
     }
 }
@@ -36,10 +38,10 @@ extension MainCommand: Command {
             let edges = makeEdges(from: structures).sorted()
             switch formatType {
             case .plantUML:
-                let treeMaker = PlantUMLFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, paths: paths)
+                let treeMaker = PlantUMLFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, excludedRIBs: excludedRIBs, paths: paths)
                 try treeMaker.make()
             case .markdown:
-                let treeMaker = MarkdownFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, paths: paths)
+                let treeMaker = MarkdownFormatTreeMaker(edges: edges, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, excludedRIBs: excludedRIBs, paths: paths)
                 try treeMaker.make()
             }
             return .success(message: "\nSuccessfully completed.".green.applyingStyle(.bold))

--- a/Sources/RIBsTreeMaker/TreeMaker/MarkdownFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/MarkdownFormatTreeMaker.swift
@@ -9,12 +9,14 @@ struct MarkdownFormatTreeMaker: TreeMaker {
     let edges: [Edge]
     let rootRIBName: String
     let shouldShowSummary: Bool
+    let excludedRIBs: [String]
     let paths: [String]
 
-    init(edges: [Edge], rootRIBName: String, shouldShowSummary: Bool, paths: [String]) {
+    init(edges: [Edge], rootRIBName: String, shouldShowSummary: Bool, excludedRIBs: [String], paths: [String]) {
         self.edges = edges
         self.rootRIBName = rootRIBName
         self.shouldShowSummary = shouldShowSummary
+        self.excludedRIBs = excludedRIBs
         self.paths = paths
     }
 
@@ -26,6 +28,10 @@ struct MarkdownFormatTreeMaker: TreeMaker {
 // MARK: - Private Methods
 private extension MarkdownFormatTreeMaker {
     func showRIBsTree(edges: [Edge], targetName: String, count: Int) throws {
+        if excludedRIBs.contains(targetName) {
+            return
+        }
+
         var summary = ""
         let maximumCount = max(0, count - 1)
         let prefix = String(repeating: "  ", count: maximumCount) + "- "

--- a/Sources/RIBsTreeMaker/TreeMaker/PlantUMLFormatTreeMaker.swift
+++ b/Sources/RIBsTreeMaker/TreeMaker/PlantUMLFormatTreeMaker.swift
@@ -9,12 +9,14 @@ struct PlantUMLFormatTreeMaker: TreeMaker {
     let edges: [Edge]
     let rootRIBName: String
     let shouldShowSummary: Bool
+    let excludedRIBs: [String]
     let paths: [String]
 
-    init(edges: [Edge], rootRIBName: String, shouldShowSummary: Bool, paths: [String]) {
+    init(edges: [Edge], rootRIBName: String, shouldShowSummary: Bool, excludedRIBs: [String], paths: [String]) {
         self.edges = edges
         self.rootRIBName = rootRIBName
         self.shouldShowSummary = shouldShowSummary
+        self.excludedRIBs = excludedRIBs
         self.paths = paths
     }
 
@@ -29,6 +31,10 @@ struct PlantUMLFormatTreeMaker: TreeMaker {
 // MARK: - Private Methods
 private extension PlantUMLFormatTreeMaker {
     func showRIBsTree(edges: [Edge], targetName: String, count: Int) throws {
+        if excludedRIBs.contains(targetName) {
+            return
+        }
+
         var summary = ""
         var indent = ""
 

--- a/Sources/RIBsTreeMaker/main.swift
+++ b/Sources/RIBsTreeMaker/main.swift
@@ -42,8 +42,9 @@ func makeCommand(commandLineArguments: [String]) -> Command {
         let rootRIBName = arguments["under"] ?? "Root"
         let shouldShowSummary = arguments["summary"] != nil
         let formatType = FormatType(value: arguments["format"])
+        let excludedRIBs = arguments["exclude"]?.components(separatedBy: ",") ?? []
 
-        return MainCommand(paths: paths, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, formatType: formatType)
+        return MainCommand(paths: paths, rootRIBName: rootRIBName, shouldShowSummary: shouldShowSummary, formatType: formatType, excludedRIBs: excludedRIBs)
     }
 }
 


### PR DESCRIPTION
## Description

* Add `--exclude` option to the command.
* This option doesn't display the specified RIB and the RIB below it.
* When specifying multiple RIB names, separate them with `,`.

## Usage

### No exclude option

command:
```sh
swift run RIBsTreeMaker [path/to/iOSproject] --under Root --format markdown
```

output:
```
- Root / root summary
  - LoggedOut(NoView) / loggedOut summary
    - TermsOfUse
      - FailedLoading
    - Welcome
      -  SignInFailedDialog
      - ForgotPassword
        - SMSAuthentication
        - ResetPassword
  - LoggedIn(NoView)
```

### With exclude option (singule)

command:
```sh
swift run RIBsTreeMaker [path/to/iOSproject] --under Root --format markdown --execlude Welcome
```

output:
```
- Root / root summary
  - LoggedOut(NoView) / loggedOut summary
    - TermsOfUse
      - FailedLoading
  - LoggedIn(NoView)
```

### With exclude option (multiple)

command:
```sh
swift run RIBsTreeMaker [path/to/iOSproject] --under Root --format markdown --execlude Welcome,TermsOfUse
```

output:
```
- Root / root summary
  - LoggedOut(NoView) / loggedOut summary
  - LoggedIn(NoView)
```