### PR TITLE
Add Support for Multiple Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RIBsTreeMaker visualize [RIBs](https://github.com/uber/RIBs) business logic tree
 
 ## Usage
 ```
-swift run RIBsTreeMaker [path/to/iOSproject] --under [RIB name] [--format [plantUML or markdown (default: plantUML)]] [--summary] [--exclude [RIB name]]
+swift run RIBsTreeMaker [path1/to/iOSproject,path2/to/be/analyzed] --under [RIB name] [--format [plantUML or markdown (default: plantUML)]] [--summary] [--exclude [RIB name]]
 ```
 
 ### Options

--- a/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
+++ b/Sources/RIBsTreeMaker/Commands/HelpCommand.swift
@@ -11,6 +11,9 @@ struct HelpCommand: Command {
     func run() -> Result {
         let helpMessage = """
         USAGE: RIBsTreeMaker <analyze target path> [options]
+        
+        Arguments:
+          <analyze target path>  Specify one or more paths separated by commas.
 
         Options:
           --under <value>      The tree will be displayed only under the RIB.

--- a/Sources/RIBsTreeMaker/main.swift
+++ b/Sources/RIBsTreeMaker/main.swift
@@ -38,7 +38,7 @@ func makeCommand(commandLineArguments: [String]) -> Command {
     case "version":
         return VersionCommand(version: version)
     default:
-        let paths = allSwiftSourcePaths(directoryPath: firstArgument)
+        let paths = firstArgument.split(separator: ",").flatMap { allSwiftSourcePaths(directoryPath: String($0)) }
         let rootRIBName = arguments["under"] ?? "Root"
         let shouldShowSummary = arguments["summary"] != nil
         let formatType = FormatType(value: arguments["format"])


### PR DESCRIPTION
# Summary
This PR introduces support for specifying multiple paths as input to the RIBsTreeMaker tool.

## Motivation
In certain scenarios, such as when using Bazel or other modular architecture solutions, RIB modules can be independent and not necessarily located within the main project directory. These independent RIB modules may also contain their own sub-RIBs. Hence, supporting multiple input paths is beneficial and necessary to correctly analyze and visualize the entire RIB hierarchy.

## Changes
1. Modified the implementation to handle multiple input paths. Specifically, the code:
```swift
let paths = allSwiftSourcePaths(directoryPath: firstArgument)
```
has been changed to:
```swift
let paths = firstArgument.split(separator: ",").flatMap { allSwiftSourcePaths(directoryPath: String($0)) }
```
2. Modified the README to reflect the new usage pattern.